### PR TITLE
Import fix for CVE-2018-1113

### DIFF
--- a/SOURCES/setup-2.8.71-CVE-2018-1113.patch
+++ b/SOURCES/setup-2.8.71-CVE-2018-1113.patch
@@ -1,0 +1,10 @@
+diff -urNp setup-2.8.71-orig/shells setup-2.8.71/shells
+--- setup-2.8.71-orig/shells	2013-06-07 16:31:32.000000000 +0200
++++ setup-2.8.71/shells	2018-06-21 13:09:40.352389479 +0200
+@@ -1,6 +1,4 @@
+ /bin/sh
+ /bin/bash
+-/sbin/nologin
+ /usr/bin/sh
+ /usr/bin/bash
+-/usr/sbin/nologin

--- a/SPECS/setup.spec
+++ b/SPECS/setup.spec
@@ -10,7 +10,7 @@
 Summary: A set of system configuration and setup files
 Name: setup
 Version: 2.8.71
-Release: 9.1%{?dist}
+Release: 9.2%{?dist}
 License: Public Domain
 Group: System Environment/Base
 URL: https://pagure.io/setup/
@@ -19,6 +19,7 @@ Source0: setup-%{xs_version}.tar.gz
 
 # XCP-ng patches
 Patch1000: setup-2.8.74.xs-delete-telemetry-user-and-group.XCP-ng.patch
+Patch1001: setup-2.8.71-CVE-2018-1113.patch
 
 BuildArch: noarch
 BuildRequires: bash perl
@@ -203,6 +204,9 @@ end
 %ghost %verify(not md5 size mtime) %config(noreplace,missingok) /etc/fstab
 
 %changelog
+* Wed Nov 20 2024 Lucas Ravagnier <lucas.ravagnier@vates.tech> - 2.8.71-9.2
+- Import from 2.8.71-10 fix for CVE-2018-1113
+
 * Tue Jun 04 2024 Samuel Verschelde <stormi-xcp@ylix.fr> - 2.8.71-9.1
 - Rebase on XenServer's 2.8.74-1, but keep versioning consistent with CentOS 7
 - Restore upstream CentOS changelog, that had been deleted by XenServer


### PR DESCRIPTION
Imported patch from redhat setup-2.8.71-10

From NIST:
> /sbin/nologin and /usr/sbin/nologin to /etc/shells. This violates security assumptions made by pam_shells and some daemons which allow access based on a user's shell being listed in /etc/shells. Under some circumstances, users which had their shell changed to /sbin/nologin could still access the system.

